### PR TITLE
remove "===" suffix of base32 encoded secret

### DIFF
--- a/otpauth.py
+++ b/otpauth.py
@@ -8,8 +8,13 @@
     :copyright: (c) 2013 by Hsiaoming Yang.
     :license: BSD, see LICENSE for more details.
 """
-
+import base64
+import hashlib
+import hmac
+import struct
 import sys
+import time
+
 
 if sys.version_info[0] == 3:
     python_version = 3
@@ -19,18 +24,17 @@ else:
     string_type = unicode
     range = xrange
 
-import base64
-import hashlib
-import hmac
-import struct
-import time
 
 __author__ = 'Hsiaoming Yang <me@lepture.com>'
 __homepage__ = 'https://github.com/lepture/otpauth'
 __version__ = '0.1.0'
 
 
-__all__ = ['OtpAuth']
+__all__ = ['OtpAuth', 'HOTP', 'TOTP']
+
+
+HOTP = 'hotp'
+TOTP = 'totp'
 
 
 class OtpAuth(object):
@@ -108,7 +112,7 @@ class OtpAuth(object):
         if type not in ('hotp', 'totp'):
             raise TypeError
 
-        secret = base64.b32encode(to_bytes(self.secret))
+        secret = base64.b32encode(to_bytes(self.secret)).strip('=')
         # bytes to string
         secret = secret.decode('utf-8')
 

--- a/test_otpauth.py
+++ b/test_otpauth.py
@@ -1,5 +1,4 @@
-# coding: utf-8
-
+# -*- coding: utf-8 -*-
 from otpauth import OtpAuth
 from nose.tools import raises
 
@@ -39,12 +38,11 @@ def test_to_google_hotp_raise():
 
 def test_to_google_hotp():
     auth = OtpAuth('python')
-    expect = ('otpauth://hotp/python?secret=OB4XI2DPNY======'
-              '&issuer=python&counter=4')
+    expect = 'otpauth://hotp/python?secret=OB4XI2DPNY&issuer=python&counter=4'
     assert auth.to_google('hotp', 'python', 'python', 4) == expect
 
 
 def test_to_google_totp():
     auth = OtpAuth('python')
-    expect = 'otpauth://totp/python?secret=OB4XI2DPNY======&issuer=python'
+    expect = 'otpauth://totp/python?secret=OB4XI2DPNY&issuer=python'
     assert auth.to_google('totp', 'python', 'python') == expect


### PR DESCRIPTION
Hi Hsiaoming,

I patched `OtpAuth.to_google` to remove "===" suffix of base32 encoded secret. Because my Google Authenticator failed to read a QRCode when "===" exists.

Please confirm my pull request and update the version.
