### PR TITLE
Support base32 encoded string as init string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ Generate and validate an otp code is very simple::
 
     >>> from otpauth import OtpAuth
     >>> auth = OtpAuth('secret')  # a secret string
+    >>> auth = OtpAuth('ONSWG4TFOQ6T2', True) # or base32 encoded string, width or widthout paddings(the '=' characters)
     >>> auth.hotp()  # generate a count based code, default count is 4
     330810
     >>> auth.valid_hotp(330810)

--- a/otpauth.py
+++ b/otpauth.py
@@ -45,6 +45,7 @@ class OtpAuth(object):
     """
 
     def __init__(self, secret, encoded=False):
+        secret += '='*(-len(secret) % 8)
         self.secret = base64.b32decode(to_bytes(secret),True) if encoded else secret
 
     def hotp(self, counter=4):

--- a/otpauth.py
+++ b/otpauth.py
@@ -44,8 +44,8 @@ class OtpAuth(object):
     :param secret: A secret token for the authentication.
     """
 
-    def __init__(self, secret):
-        self.secret = secret
+    def __init__(self, secret, encoded=False):
+        self.secret = base64.b32decode(to_bytes(secret),True) if encoded else secret
 
     def hotp(self, counter=4):
         """Generate a HOTP code.


### PR DESCRIPTION
Thank you for your work, It help me a lot.

When I uses this as a client, I find that I must use it like this:
>auth = OtpAuth(base64.b32decode('ONSWG4TFOQ6T2',True))

so, I want the init function can do these things:
>auth = OtpAuth('ONSWG4TFOQ6T2',encoded=True)
> or
> auth = OtpAuth('ONSWG4TFOQ6T2',True)

and it Compatible with old code：
> auth = OtpAuth('secret')