### PR TITLE
verify(): use formatted strings instead of bytes

### DIFF
--- a/src/otpauth/rfc4226.py
+++ b/src/otpauth/rfc4226.py
@@ -35,7 +35,7 @@ class HOTP(OTP):
         """
         if len(str(code)) > self.digit:
             return False
-        return hmac.compare_digest(bytes(self.generate(counter)), bytes(code))
+        return hmac.compare_digest(f'{self.generate(counter):0{self.digit}}', f'{code:0{self.digit}}')
 
     def to_uri(self, label: str, issuer: str, counter: int) -> str:  # type: ignore[override]
         """Generate the otpauth protocal string for HOTP.

--- a/src/otpauth/rfc6238.py
+++ b/src/otpauth/rfc6238.py
@@ -40,7 +40,7 @@ class TOTP(OTP):
         """
         if len(str(code)) > self.digit:
             return False
-        return hmac.compare_digest(bytes(self.generate(timestamp)), bytes(code))
+        return hmac.compare_digest(f'{self.generate(timestamp):0{self.digit}}', f'{code:0{self.digit}}')
 
     def to_uri(self, label: str, issuer: str) -> str:  # type: ignore[override]
         """Generate the otpauth protocal string for TOTP.


### PR DESCRIPTION
a proposed fix for #10
