### PR TITLE
avoid verify to raise an exception when the code argument is non-ascii

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,13 @@ Changelog
 
 For **v1**, please head over to https://pythonhosted.org/otpauth/
 
+2.1.2
+-----
+
+**Unreleased**
+
+- Avoid ``verify`` to raise an exception when the ``code`` argument is non-ascii.
+
 2.1.1
 -----
 

--- a/src/otpauth/_rfc4226.py
+++ b/src/otpauth/_rfc4226.py
@@ -37,7 +37,10 @@ class HOTP(OTP):
         """
         if len(str(code)) > self.digit:
             return False
-        return hmac.compare_digest(self.string_code(self.generate(counter)), self.string_code(code))
+        try:
+            return hmac.compare_digest(self.string_code(self.generate(counter)), self.string_code(code))
+        except (TypeError, ValueError):
+            return False
 
     def to_uri(self, label: str, issuer: str, counter: int) -> str:
         """Generate the otpauth protocal string for HOTP.

--- a/src/otpauth/_rfc6238.py
+++ b/src/otpauth/_rfc6238.py
@@ -42,7 +42,11 @@ class TOTP(OTP):
         """
         if len(str(code)) > self.digit:
             return False
-        return hmac.compare_digest(self.string_code(self.generate(timestamp)), self.string_code(code))
+
+        try:
+            return hmac.compare_digest(self.string_code(self.generate(timestamp)), self.string_code(code))
+        except (TypeError, ValueError):
+            return False
 
     def to_uri(self, label: str, issuer: str) -> str:
         """Generate the otpauth protocal string for TOTP.

--- a/tests/test_hotp.py
+++ b/tests/test_hotp.py
@@ -18,7 +18,10 @@ class TestHOTP(unittest.TestCase):
         # due to not match
         self.assertFalse(self.hotp.verify(12345, 0))
 
+        self.assertFalse(self.hotp.verify("●●●●●●", 0))
+
         self.assertTrue(self.hotp.verify(170566, 0))
+
 
     def test_to_uri(self):
         uri = self.hotp.to_uri("Typlog:lepture.com", "Authlib", 0)

--- a/tests/test_totp.py
+++ b/tests/test_totp.py
@@ -19,6 +19,7 @@ class TestTOTP(unittest.TestCase):
 
         # due to not match
         self.assertFalse(self.totp.verify(12345, FIXED_TIME))
+        self.assertFalse(self.totp.verify("●●●●●●", FIXED_TIME))
 
         self.assertTrue(self.totp.verify(129815, FIXED_TIME))
 


### PR DESCRIPTION
I encountered an issue when my browser accidentally filled the input field with `●●●●●●`.